### PR TITLE
Add Node Server example

### DIFF
--- a/examples/carplay-node-server/.gitignore
+++ b/examples/carplay-node-server/.gitignore
@@ -1,0 +1,2 @@
+public/bundle.js
+server/index.js

--- a/examples/carplay-node-server/README.md
+++ b/examples/carplay-node-server/README.md
@@ -1,0 +1,24 @@
+# Running this example
+
+In the root folder of node-CarPlay run:
+```
+pnpm i
+pnpm build
+```
+
+Then in this folder:
+```
+npm i
+npm start
+# To listen to audio
+ffplay -f s16le -ar 44100 -ac 2 http://localhost:3000/stream/audio
+# To see video and initialize dongle
+# open http://localhost:3000/ in your browser
+# To see raw h264 stream, open http://localhost:3000/stream/video
+# in your video player.
+```
+
+On Raspberry Pi make sure to also grant plugdev permissions to usb devices
+```
+echo "SUBSYSTEM==\"usb\", ATTR{idVendor}==\"1314\", ATTR{idProduct}==\"152*\", MODE=\"0660\", GROUP=\"plugdev\"" | sudo tee /etc/udev/rules.d/52-nodecarplay.rules
+```

--- a/examples/carplay-node-server/client/App.tsx
+++ b/examples/carplay-node-server/client/App.tsx
@@ -21,7 +21,7 @@ function App() {
       node: 'video',
       mode: 'video',
       fps: config.fps,
-      flushingTime: 100,
+      flushingTime: 0,
       debug: false,
     })
 

--- a/examples/carplay-node-server/client/App.tsx
+++ b/examples/carplay-node-server/client/App.tsx
@@ -1,0 +1,125 @@
+import { useCallback, useEffect, useState, useRef } from 'react'
+import JMuxer from 'jmuxer'
+import { TouchAction } from 'node-carplay/dist/web'
+
+export const config = {
+  width: window.innerWidth,
+  height: window.innerHeight,
+  fps: 30,
+}
+
+function App() {
+  const [pointerdown, setPointerDown] = useState(false)
+
+  const connectionRef = useRef<WebSocket | null>(null)
+
+  useEffect(() => {
+    if (connectionRef.current) {
+      return
+    }
+    const jmuxer = new JMuxer({
+      node: 'video',
+      mode: 'video',
+      fps: config.fps,
+      flushingTime: 100,
+      debug: false,
+    })
+
+    const connectionUrl = new URL('/', window.location.href)
+    connectionUrl.protocol = connectionUrl.protocol.replace('http', 'ws')
+
+    const connection = new WebSocket(connectionUrl.href)
+    connectionRef.current = connection
+
+    connection.onopen = () => {
+      connection.send(
+        JSON.stringify({
+          type: 'start',
+          ...config,
+        }),
+      )
+    }
+
+    fetch(`/stream/video`)
+      .then(async response => {
+        const reader = response.body!.getReader()
+
+        // eslint-disable-next-line no-constant-condition
+        while (true) {
+          const { value, done } = await reader.read()
+          if (done) break
+          jmuxer.feed({
+            video: value,
+            duration: 0,
+          })
+        }
+      })
+      .catch(err => {
+        console.error('Error in video stream', err)
+      })
+  }, [])
+
+  const sendTouchEvent: React.PointerEventHandler<HTMLDivElement> = useCallback(
+    e => {
+      let action = TouchAction.Up
+      if (e.type === 'pointerdown') {
+        action = TouchAction.Down
+        setPointerDown(true)
+      } else if (pointerdown) {
+        switch (e.type) {
+          case 'pointermove':
+            action = TouchAction.Move
+            break
+          case 'pointerup':
+          case 'pointercancel':
+          case 'pointerout':
+            setPointerDown(false)
+            action = TouchAction.Up
+            break
+        }
+      } else {
+        return
+      }
+
+      const { offsetX: x, offsetY: y } = e.nativeEvent
+
+      connectionRef.current?.send(
+        JSON.stringify({
+          type: 'touch',
+          x,
+          y,
+          action,
+        }),
+      )
+    },
+    [pointerdown],
+  )
+
+  return (
+    <div
+      style={{ height: '100%', touchAction: 'none', cursor: 'default' }}
+      id={'main'}
+      className="App"
+    >
+      <div
+        id="videoContainer"
+        onPointerDown={sendTouchEvent}
+        onPointerMove={sendTouchEvent}
+        onPointerUp={sendTouchEvent}
+        onPointerCancel={sendTouchEvent}
+        onPointerOut={sendTouchEvent}
+        style={{
+          height: '100%',
+          width: '100%',
+          padding: 0,
+          margin: 0,
+          display: 'flex',
+        }}
+      >
+        <video id="video" style={{ height: '100%' }} autoPlay muted />
+      </div>
+    </div>
+  )
+}
+
+export default App

--- a/examples/carplay-node-server/client/index.tsx
+++ b/examples/carplay-node-server/client/index.tsx
@@ -1,0 +1,5 @@
+import ReactDOM from 'react-dom/client'
+import App from './App'
+
+const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)
+root.render(<App />)

--- a/examples/carplay-node-server/package.json
+++ b/examples/carplay-node-server/package.json
@@ -28,6 +28,7 @@
     "build": "npm run build:server && npm run build:client",
     "build:server": "esbuild server/index.ts --bundle --outfile=server/index.js --define:process.env.NODE_ENV=\\\"production\\\" --platform=node --external:usb --external:node-microphone --external:ws --external:express --external:cors",
     "build:client": "esbuild client/index.tsx --bundle --outfile=public/bundle.js --define:process.env.NODE_ENV=\\\"production\\\" --alias:events=events --alias:stream=stream-browserify --alias:buffer=buffer",
+    "watch:server": "npm run build:client -- --watch",
     "watch:client": "npm run build:client -- --watch",
     "dev:server": "ts-node server/index.ts",
     "start": "node server/index.js",

--- a/examples/carplay-node-server/package.json
+++ b/examples/carplay-node-server/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "carplay-node-server",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.18.2",
+    "node-carplay": "file:../../",
+    "ws": "^8.14.0"
+  },
+  "devDependencies": {
+    "@types/cors": "^2.8.14",
+    "@types/express": "^4.17.17",
+    "@types/jmuxer": "^2.0.3",
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "@types/ws": "^8.5.5",
+    "buffer": "^6.0.3",
+    "esbuild": "^0.19.2",
+    "events": "^3.3.0",
+    "jmuxer": "^2.0.5",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "stream-browserify": "^3.0.0",
+    "ts-node": "^10.9.1"
+  },
+  "scripts": {
+    "build": "npm run build:server && npm run build:client",
+    "build:server": "esbuild server/index.ts --bundle --outfile=server/index.js --define:process.env.NODE_ENV=\\\"production\\\" --platform=node --external:usb --external:node-microphone --external:ws --external:express --external:cors",
+    "build:client": "esbuild client/index.tsx --bundle --outfile=public/bundle.js --define:process.env.NODE_ENV=\\\"production\\\" --alias:events=events --alias:stream=stream-browserify --alias:buffer=buffer",
+    "watch:client": "npm run build:client -- --watch",
+    "dev:server": "ts-node server/index.ts",
+    "start": "node server/index.js",
+    "prepare": "npm run build"
+  },
+  "optionalDependencies": {
+    "bufferutil": "^4.0.7",
+    "utf-8-validate": "^6.0.3"
+  }
+}

--- a/examples/carplay-node-server/public/index.html
+++ b/examples/carplay-node-server/public/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
+    <title>CarPlay App</title>
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+    <script src="./bundle.js" type="application/javascript"></script>
+  </body>
+</html>

--- a/examples/carplay-node-server/server/index.ts
+++ b/examples/carplay-node-server/server/index.ts
@@ -1,0 +1,149 @@
+import cors from 'cors'
+import http from 'http'
+import express from 'express'
+import WebSocket, { WebSocketServer } from 'ws'
+
+import CarPlayNode, {
+  DongleConfig,
+  SendTouch,
+  decodeTypeMap,
+} from 'node-carplay/dist/node'
+import path from 'path'
+
+const PORT = parseInt(process.env.PORT ?? '', 10) || 3000
+const PATH_STATIC = path.join(__dirname, '..', 'public')
+
+const config: DongleConfig = {
+  dpi: 160,
+  nightMode: false,
+  hand: 0,
+  boxName: 'nodePlay',
+  mediaDelay: 0,
+  audioTransferMode: false,
+
+  fps: 0,
+  width: 0,
+  height: 0,
+}
+
+let formatPrinted = false
+
+async function main() {
+  let carPlay: CarPlayNode | null = null
+
+  const clientsAudio = new Set<http.ServerResponse>()
+  const clientsVideo = new Set<http.ServerResponse>()
+
+  async function setupCarPlay({
+    width,
+    height,
+    fps,
+  }: {
+    width: number
+    height: number
+    fps: number
+  }): Promise<void> {
+    if (carPlay != null) {
+      return
+    }
+    config.width = width
+    config.height = height
+    config.fps = fps
+
+    carPlay = new CarPlayNode(config)
+
+    carPlay.onmessage = function ({ type, message }) {
+      if (type === 'plugged') {
+        console.log('statusChange plugged')
+      } else if (type === 'unplugged') {
+        console.log('statusChange unplugged')
+      } else if (type === 'video') {
+        if (message.data != null) {
+          clientsVideo.forEach(client => {
+            client.write(message.data)
+          })
+        }
+      } else if (type === 'audio') {
+        const { data } = message
+        if (data != null) {
+          clientsAudio.forEach(client => {
+            client.write(Buffer.from(data.buffer))
+          })
+        }
+        if (!formatPrinted && message.decodeType != null) {
+          formatPrinted = true
+          const audioFormat = decodeTypeMap[message.decodeType]
+          console.log('Audio format', audioFormat)
+        }
+      }
+    }
+
+    await carPlay.start()
+  }
+
+  const app = express()
+
+  app.use(cors())
+
+  app.get('/stream/audio', (req, res) => {
+    res.writeHead(200)
+    clientsAudio.add(res)
+    res.on('end', () => {
+      clientsAudio.delete(res)
+    })
+  })
+  app.get('/stream/video', (req, res) => {
+    res.writeHead(200, {
+      'Content-Type': 'video/h264',
+      'Access-Control-Allow-Origin': req.headers.origin ?? '*',
+    })
+    clientsVideo.add(res)
+    res.on('end', () => {
+      clientsVideo.delete(res)
+    })
+  })
+
+  app.use(express.static(PATH_STATIC))
+
+  const server = app.listen(PORT)
+
+  const wss = new WebSocketServer({ server })
+
+  wss.on('connection', (ws: WebSocket) => {
+    ws.on('message', (chunk: Buffer) => {
+      let message = null
+
+      try {
+        message = JSON.parse(chunk.toString('utf8'))
+      } catch (_) {
+        // Ignore malformed messages
+        console.debug('Malformed message', message)
+        return
+      }
+
+      if (typeof message !== 'object' || message == null) {
+        // Ignore malformed messages
+        return
+      }
+
+      if (message.type === 'start') {
+        const { width, height, fps } = message
+        setupCarPlay({ width, height, fps }).catch(err => {
+          console.error('Error setting up carplay', { err })
+        })
+      } else if (message.type === 'touch') {
+        const { x, y, action } = message
+        carPlay?.dongleDriver.send(
+          new SendTouch(x / config.width, y / config.height, action),
+        )
+      }
+    })
+  })
+
+  console.log([`Server listening on http://localhost:${PORT}/`].join('\n'))
+}
+
+main().catch(err => {
+  console.error(`Error initializing server`, { err })
+  process.exit(1)
+})

--- a/examples/carplay-node-server/server/index.ts
+++ b/examples/carplay-node-server/server/index.ts
@@ -4,7 +4,7 @@ import express from 'express'
 import WebSocket, { WebSocketServer } from 'ws'
 
 import CarPlayNode, {
-  DongleConfig,
+  CarplayNodeConfig,
   SendTouch,
   decodeTypeMap,
 } from 'node-carplay/dist/node'
@@ -13,13 +13,14 @@ import path from 'path'
 const PORT = parseInt(process.env.PORT ?? '', 10) || 3000
 const PATH_STATIC = path.join(__dirname, '..', 'public')
 
-const config: DongleConfig = {
+const config: CarplayNodeConfig = {
   dpi: 160,
   nightMode: false,
   hand: 0,
   boxName: 'nodePlay',
   mediaDelay: 0,
   audioTransferMode: false,
+  playAudio: true,
 
   fps: 0,
   width: 0,

--- a/examples/carplay-node-server/tsconfig.json
+++ b/examples/carplay-node-server/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+  },
+  "include": ["server/*.ts", "client"]
+}

--- a/examples/carplay-web-app-direct/src/App.tsx
+++ b/examples/carplay-web-app-direct/src/App.tsx
@@ -72,7 +72,7 @@ function App() {
       node: 'video',
       mode: 'video',
       fps: config.fps,
-      flushingTime: 100,
+      flushingTime: 0,
       debug: false,
     })
     setJmuxer(jmuxer)

--- a/examples/carplay-web-app-worker/src/App.tsx
+++ b/examples/carplay-web-app-worker/src/App.tsx
@@ -78,7 +78,7 @@ function App() {
       node: 'video',
       mode: 'video',
       fps: config.fps,
-      flushingTime: 100,
+      flushingTime: 0,
       debug: false,
     })
     setJmuxer(jmuxer)

--- a/src/node/NodeSpeaker.ts
+++ b/src/node/NodeSpeaker.ts
@@ -1,0 +1,65 @@
+import { ChildProcess, spawn } from 'child_process'
+import { AudioData, decodeTypeMap } from '../modules'
+
+const AUDIO_PROCESS_RETRY_INTERVAL_MS = 5000
+
+export default class NodeSpeaker {
+  private _cantPlayAudio = false
+  private _playerByDecodeType: Map<number, ChildProcess> = new Map()
+
+  private getPlayer(decodeType: number) {
+    let player = this._playerByDecodeType.get(decodeType)
+    if (player == null) {
+      if (this._cantPlayAudio) {
+        return null
+      }
+
+      const format = decodeTypeMap[decodeType]
+
+      player = spawn('ffplay', [
+        '-f',
+        `s${format.bitrate}le`,
+        `-ar`,
+        `${format.frequency}`,
+        `-ac`,
+        `${format.channel}`,
+        '-nodisp',
+        `-`,
+      ])
+
+      this._playerByDecodeType.set(decodeType, player)
+
+      player.on('exit', code => {
+        this._playerByDecodeType.delete(decodeType)
+
+        console.log(`Child process exited with code ${code}`)
+      })
+
+      player.on('error', err => {
+        console.error('Failed to start audio process.', err)
+
+        if (!this._cantPlayAudio) {
+          // The usecase here is when the user does not have ffplay installed.
+          // We don't want to flood the console with errors, and we don't want
+          // to retry to spawn the process over and over again.
+          this._cantPlayAudio = true
+          setTimeout(() => {
+            this._cantPlayAudio = false
+          }, AUDIO_PROCESS_RETRY_INTERVAL_MS)
+        }
+      })
+    }
+
+    return player
+  }
+
+  public feed(message: AudioData) {
+    const { data, decodeType } = message
+
+    if (data != null && decodeType != null) {
+      const player = this.getPlayer(decodeType)
+
+      player?.stdin?.write(Buffer.from(data.buffer))
+    }
+  }
+}

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -1,5 +1,5 @@
-import CarplayNode from './CarplayNode'
+export { default, CarplayNodeConfig } from './CarplayNode'
 
 export * from '../modules'
 export { default as NodeMicrophone } from './NodeMicrophone'
-export default CarplayNode
+export { default as NodeSpeaker } from './NodeSpeaker'


### PR DESCRIPTION
This PR adds an additional example where instead of handling the dongle through the browser, it does so in a Node.js server while the browser still decodes the video and handles touch input mapping.

This could be useful for scenarios where you want a daemon-like setup and want the ability to move away from the video output, and come back to it (like in car infotainment systems).

Having a background daemon for dongle makes sure that the dongle stays booted and ready to serve output immediately. It also allows us to bypass the chromium audio stack, and use 3rd party utilities (I recommended `ffplay` from `ffmpeg` in the example).

NB! The microphone in the `node` version of `node-carplay` doesn't work, but that's outside the scope of the example. Will probably open a separate PR fixing it.