### PR TITLE
Node API fixes and parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
     Node Carplay npm package
 </p>
 
-    
-<a href="https://www.buymeacoffee.com/rhysm" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/default-orange.png" alt="Buy Me A Coffee" height="41" width="174"></a>   
+
+<a href="https://www.buymeacoffee.com/rhysm" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/default-orange.png" alt="Buy Me A Coffee" height="41" width="174"></a>
 
 
 <!-- TABLE OF CONTENTS -->
@@ -46,7 +46,7 @@
 
 This is a carplay module for nodejs. It is currently in development, but is at a useable stage. Currently it interacts with a Carlinkit adapter, it opens communication with it, sends various
 configuration settings and also downloads the APK file thats usually used with it. The APK file then gets extracted and its contents get sent over usb to the
-dongle itself. The dongle then sends a h264 bytestream from the phone, this contains the video data. And it also sends an audio stream. 
+dongle itself. The dongle then sends a h264 bytestream from the phone, this contains the video data. And it also sends an audio stream.
 
 ### Built With
 
@@ -65,7 +65,7 @@ This project would not of been possible without electric monks work on a python 
 
 ### Prerequisites
 
-The target machine should have FFMPEG/FFPLAY installed and working 
+The target machine should have FFMPEG/FFPLAY installed and working
 
 ### Installation
 
@@ -73,7 +73,11 @@ The target machine should have FFMPEG/FFPLAY installed and working
 npm install node-carplay
 ```
 
+If you are on macOS, you need `sox` for `node-microphone` (for the `node` environment)
 
+```shell
+brew install sox
+```
 
 <!-- USAGE EXAMPLES -->
 ## Usage

--- a/src/modules/DongleDriver.ts
+++ b/src/modules/DongleDriver.ts
@@ -64,11 +64,10 @@ export class DongleDriver extends EventEmitter {
 
     try {
       this._device = device
-      console.debug('opening')
 
       console.debug('initializing')
       if (!device.opened) {
-        throw new Error('Illegal state - device not opened')
+        throw new DriverStateError('Illegal state - device not opened')
       }
       await this._device.selectConfiguration(CONFIG_NUMBER)
 

--- a/src/modules/DongleDriver.ts
+++ b/src/modules/DongleDriver.ts
@@ -53,6 +53,10 @@ export class DongleDriver extends EventEmitter {
     { vendorId: 0x1314, productId: 0x1521 },
   ]
 
+  // NB! Make sure to reset the device outside of this class
+  // Resetting device through node-usb can cause transfer issues
+  // and for it to "disappear"
+
   initialise = async (device: USBDevice) => {
     if (this._device) {
       return
@@ -62,8 +66,10 @@ export class DongleDriver extends EventEmitter {
       this._device = device
       console.debug('opening')
 
-      await this._device.open()
-      await this._device.reset()
+      console.debug('initializing')
+      if (!device.opened) {
+        throw new Error('Illegal state - device not opened')
+      }
       await this._device.selectConfiguration(CONFIG_NUMBER)
 
       if (!this._device.configuration) {

--- a/src/node/CarplayNode.ts
+++ b/src/node/CarplayNode.ts
@@ -15,6 +15,7 @@ import {
   DEFAULT_CONFIG,
   Key,
   CarPlay,
+  AudioCommand,
 } from '../modules'
 
 const USB_WAIT_PERIOD_MS = 500
@@ -57,6 +58,20 @@ export default class CarplayNode {
         this.onmessage?.({ type: 'media', message })
       } else if (message instanceof CarPlay) {
         this.onmessage?.({ type: 'carplay', message })
+      }
+
+      // Trigger internal event logic
+      if (message instanceof AudioData && message.command != null) {
+        switch (message.command) {
+          case AudioCommand.AudioSiriStart:
+          case AudioCommand.AudioPhonecallStart:
+            mic.start()
+            break
+          case AudioCommand.AudioSiriStop:
+          case AudioCommand.AudioPhonecallStop:
+            mic.stop()
+            break
+        }
       }
     })
     this.dongleDriver = driver

--- a/src/node/CarplayNode.ts
+++ b/src/node/CarplayNode.ts
@@ -20,7 +20,7 @@ import {
 const USB_WAIT_PERIOD_MS = 500
 const USB_WAIT_RESTART_MS = 3000
 
-export default class CarplayWS extends EventEmitter {
+export default class CarplayNode extends EventEmitter {
   private _pairTimeout: NodeJS.Timeout | null = null
   private _plugged = false
   private _dongleDriver: DongleDriver

--- a/src/node/CarplayNode.ts
+++ b/src/node/CarplayNode.ts
@@ -3,7 +3,6 @@ import NodeMicrophone from './NodeMicrophone'
 import EventEmitter from 'events'
 import {
   AudioData,
-  Key,
   MediaData,
   Message,
   Plugged,
@@ -15,6 +14,7 @@ import {
   DongleDriver,
   DongleConfig,
   DEFAULT_CONFIG,
+  Key,
 } from '../modules'
 
 const USB_WAIT_PERIOD_MS = 500
@@ -23,8 +23,8 @@ const USB_WAIT_RESTART_MS = 3000
 export default class CarplayNode extends EventEmitter {
   private _pairTimeout: NodeJS.Timeout | null = null
   private _plugged = false
-  private _dongleDriver: DongleDriver
   private _config: DongleConfig
+  public dongleDriver: DongleDriver
 
   constructor(config: DongleConfig = DEFAULT_CONFIG) {
     super()
@@ -53,7 +53,7 @@ export default class CarplayNode extends EventEmitter {
         this.emit('media', message)
       }
     })
-    this._dongleDriver = driver
+    this.dongleDriver = driver
   }
 
   private async findDevice() {
@@ -81,10 +81,6 @@ export default class CarplayNode extends EventEmitter {
     this.emitPlugged()
   }
 
-  sendTouch = ({ type, x, y }: { type: number; x: number; y: number }) => {
-    this._dongleDriver.send(new SendTouch(x, y, type))
-  }
-
   start = async () => {
     // Find device to "reset" first
     let device = await this.findDevice()
@@ -106,7 +102,7 @@ export default class CarplayNode extends EventEmitter {
 
     let initialised = false
     try {
-      const { initialise, open, send } = this._dongleDriver
+      const { initialise, open, send } = this.dongleDriver
       await initialise(device)
       await open(this._config)
       this._pairTimeout = setTimeout(() => {
@@ -131,6 +127,9 @@ export default class CarplayNode extends EventEmitter {
   }
 
   sendKey = (action: Key) => {
-    this._dongleDriver.send(new SendCarPlay(action))
+    this.dongleDriver.send(new SendCarPlay(action))
+  }
+  sendTouch = ({ type, x, y }: { type: number; x: number; y: number }) => {
+    this.dongleDriver.send(new SendTouch(x, y, type))
   }
 }

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -1,3 +1,5 @@
 import CarplayNode from './CarplayNode'
 
+export * from '../modules'
+export { default as NodeMicrophone } from './NodeMicrophone'
 export default CarplayNode

--- a/src/web/CarplayWeb.ts
+++ b/src/web/CarplayWeb.ts
@@ -89,6 +89,11 @@ export default class CarplayWeb {
   start = async (usbDevice: USBDevice) => {
     if (this._started) return
     const { initialise, open, send } = this.dongleDriver
+
+    console.debug('opening device')
+    await usbDevice.open()
+    await usbDevice.reset()
+
     await initialise(usbDevice)
     await open(this._config)
     this._pairTimeout = setTimeout(() => {

--- a/src/web/CarplayWeb.ts
+++ b/src/web/CarplayWeb.ts
@@ -13,8 +13,8 @@ import { DongleDriver, DongleConfig } from '../modules'
 const { knownDevices } = DongleDriver
 
 export type CarplayMessage =
-  | { type: 'plugged' }
-  | { type: 'unplugged' }
+  | { type: 'plugged'; message?: undefined }
+  | { type: 'unplugged'; message?: undefined }
   | { type: 'audio'; message: AudioData }
   | { type: 'video'; message: VideoData }
   | { type: 'media'; message: MediaData }

--- a/src/web/WebMicrophone.ts
+++ b/src/web/WebMicrophone.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'events'
 
-export class WebMicrophone extends EventEmitter {
+export default class WebMicrophone extends EventEmitter {
   private active = false
   private sampleRate = 16000
   private audioContext: AudioContext

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -1,6 +1,6 @@
 import CarplayWeb from './CarplayWeb'
 
 export * from '../modules'
-export { WebMicrophone } from './WebMicrophone'
+export { default as WebMicrophone } from './WebMicrophone'
 export * from './CarplayWeb'
 export default CarplayWeb


### PR DESCRIPTION
This is all the changes that are required to make the node API work for the server usecase in #18

It also includes fixes for the 2023 dongles (see the libusb transfer error commit) and making the API for web and node nearly identical, in addition to fixing bugs in the API

This is the subset of changes in #18 and should be good to merge. I'm unsure whether it's a good idea/wanted example, to have a nodejs server and a react client where the mic and the audio are handled by the nodejs server and react is just for video output and relaying touch information, lmk what your thoughts are.