### PR TITLE
Feature: add support for audioTransferMode

### DIFF
--- a/examples/carplay-web-app-direct/src/App.tsx
+++ b/examples/carplay-web-app-direct/src/App.tsx
@@ -19,7 +19,8 @@ export const config: DongleConfig = {
   width: window.innerWidth,
   height: window.innerHeight,
   fps: 60,
-  mediaDelay: 0
+  mediaDelay: 0,
+  audioTranferMode: false
 }
 
 function App() {

--- a/examples/carplay-web-app-worker/src/App.tsx
+++ b/examples/carplay-web-app-worker/src/App.tsx
@@ -19,7 +19,8 @@ export const config: DongleConfig = {
   width: window.innerWidth,
   height: window.innerHeight,
   fps: 60,
-  mediaDelay: 0
+  mediaDelay: 0,
+  audioTranferMode: false
 }
 
 function App() {

--- a/scripts/startnode.ts
+++ b/scripts/startnode.ts
@@ -9,6 +9,7 @@ const config: DongleConfig = {
   height: 600,
   fps: 20,
   mediaDelay: 300,
+  audioTranferMode: false,
 }
 
 const carplay = new CarplayNode(config)

--- a/src/modules/DongleDriver.ts
+++ b/src/modules/DongleDriver.ts
@@ -25,6 +25,7 @@ export type DongleConfig = {
   boxName: string
   hand: number
   mediaDelay: number
+  audioTranferMode: boolean
 }
 
 export const DEFAULT_CONFIG: DongleConfig = {
@@ -36,6 +37,7 @@ export const DEFAULT_CONFIG: DongleConfig = {
   nightMode: false,
   hand: 0,
   mediaDelay: 300,
+  audioTranferMode: false,
 }
 
 export class DriverStateError extends Error {}
@@ -185,6 +187,7 @@ export class DongleDriver extends EventEmitter {
       nightMode: _nightMode,
       boxName: _boxName,
       mediaDelay,
+      audioTranferMode,
     } = config
     const initMessages = [
       new SendNumber(_dpi, FileAddress.DPI),
@@ -195,6 +198,7 @@ export class DongleDriver extends EventEmitter {
       new SendString(_boxName, FileAddress.BOX_NAME),
       new SendBoxSettings(mediaDelay),
       new SendCarPlay('wifiEn'),
+      new SendCarPlay(audioTranferMode ? 'audioToCar' : 'audioToDongle'),
     ]
     await Promise.all(initMessages.map(this.send))
     setTimeout(() => {

--- a/src/modules/messages.ts
+++ b/src/modules/messages.ts
@@ -9,6 +9,8 @@ export enum KeyMapping {
   left = 100, //'Button Left',
   right = 101, //'Button Right',
   frame = 12,
+  audioToCar = 22, // Phone will Stream audio directly to car system and not dongle
+  audioToDongle = 23, // Phone will stream audio to the dongle and it will send it over the link - DEFAULT
   selectDown = 104, //'Button Select Down',
   selectUp = 105, //'Button Select Up',
   back = 106, //'Button Back',


### PR DESCRIPTION
As requested in https://github.com/rhysmorgan134/node-CarPlay/issues/19 - this enabled us to set audioTransferMode and let the phone keep playing audio (or stream to to some other BT source like the car)