### PR TITLE
Feature: fix tests clean up ts configs

### DIFF
--- a/examples/carplay-web-app-direct/README.md
+++ b/examples/carplay-web-app-direct/README.md
@@ -3,8 +3,7 @@
 In the root folder of node-CarPlay run:
 ```
 pnpm i
-pnpm build:node
-pnpm build:web
+pnpm build
 ```
 
 Then in this folder:
@@ -14,8 +13,6 @@ npm start
 ```
 
 Make sure chrome has "Experimental Web Platform features" enabled in chrome://flags.
-
-You might need to run chrome with `--disable-webusb-security` as usb devices can be interacted from https only.
 
 On Raspberry Pi make sure to also grant plugdev permissions to usb devices
 ```

--- a/examples/carplay-web-app-direct/src/App.tsx
+++ b/examples/carplay-web-app-direct/src/App.tsx
@@ -20,7 +20,7 @@ export const config: DongleConfig = {
   height: window.innerHeight,
   fps: 60,
   mediaDelay: 0,
-  audioTransferMode: false
+  audioTransferMode: false,
 }
 
 function App() {

--- a/examples/carplay-web-app-direct/src/setupProxy.js
+++ b/examples/carplay-web-app-direct/src/setupProxy.js
@@ -1,7 +1,7 @@
 module.exports = function (app) {
   app.use(function (req, res, next) {
-    res.setHeader("Cross-Origin-Opener-Policy", "same-origin");
-    res.setHeader("Cross-Origin-Embedder-Policy", "require-corp");
-    next();
-});
-};
+    res.setHeader('Cross-Origin-Opener-Policy', 'same-origin')
+    res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp')
+    next()
+  })
+}

--- a/examples/carplay-web-app-worker/README.md
+++ b/examples/carplay-web-app-worker/README.md
@@ -3,8 +3,7 @@
 In the root folder of node-CarPlay run:
 ```
 pnpm i
-pnpm build:node
-pnpm build:web
+pnpm build
 ```
 
 Then in this folder:
@@ -14,8 +13,6 @@ npm start
 ```
 
 Make sure chrome has "Experimental Web Platform features" enabled in chrome://flags.
-
-You might need to run chrome with `--disable-webusb-security` as usb devices can be interacted from https only.
 
 On Raspberry Pi make sure to also grant plugdev permissions to usb devices
 ```

--- a/examples/carplay-web-app-worker/src/App.tsx
+++ b/examples/carplay-web-app-worker/src/App.tsx
@@ -20,7 +20,7 @@ export const config: DongleConfig = {
   height: window.innerHeight,
   fps: 60,
   mediaDelay: 0,
-  audioTransferMode: false
+  audioTransferMode: false,
 }
 
 function App() {

--- a/examples/carplay-web-app-worker/src/setupProxy.js
+++ b/examples/carplay-web-app-worker/src/setupProxy.js
@@ -1,7 +1,7 @@
 module.exports = function (app) {
   app.use(function (req, res, next) {
-    res.setHeader("Cross-Origin-Opener-Policy", "same-origin");
-    res.setHeader("Cross-Origin-Embedder-Policy", "require-corp");
-    next();
-});
-};
+    res.setHeader('Cross-Origin-Opener-Policy', 'same-origin')
+    res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp')
+    next()
+  })
+}

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
     "config:icon": "ts-node ./scripts/configIcon.ts",
     "test": "jest --silent",
     "coverage": "jest --silent --coverage",
-    "build:node": "tsc --build",
-    "build:web": "tsc --build ./src/web/tsconfig.json",
-    "clean": "tsc --build --clean",
+    "build": "tsc --build ./tsconfig.build.json ./src/web/tsconfig.json",
+    "watch": "tsc --build ./tsconfig.build.json ./src/web/tsconfig.json --watch",
+    "clean": "tsc --build --clean ./ ./src/web/tsconfig.json",
     "typecheck": "tsc --noEmit",
     "lint": "eslint --ext .js,.ts,.tsx .",
     "format": "prettier --ignore-path .gitignore --write \"**/*.+(js|ts|tsx|json)\""

--- a/src/modules/DongleDriver.ts
+++ b/src/modules/DongleDriver.ts
@@ -178,7 +178,7 @@ export class DongleDriver extends EventEmitter {
     }
   }
 
-  open = async (config: DongleConfig) => {
+  start = async (config: DongleConfig) => {
     if (!this._device) {
       throw new DriverStateError('No device set - call initialise first')
     }

--- a/src/modules/__tests__/messages.test.ts
+++ b/src/modules/__tests__/messages.test.ts
@@ -228,7 +228,9 @@ describe('Readable Messages', () => {
       expect((message as AudioData).decodeType).toBe(1)
       expect((message as AudioData).volume).toBe(0.5)
       expect((message as AudioData).audioType).toBe(1)
-      expect((message as AudioData).data).toStrictEqual(data.subarray(12))
+      expect((message as AudioData).data).toStrictEqual(
+        new Int16Array(data.buffer, 12),
+      )
     })
 
     it('constructs message with volume duration', () => {

--- a/src/node/CarplayNode.ts
+++ b/src/node/CarplayNode.ts
@@ -119,9 +119,9 @@ export default class CarplayNode {
 
     let initialised = false
     try {
-      const { initialise, open, send } = this.dongleDriver
+      const { initialise, start, send } = this.dongleDriver
       await initialise(device)
-      await open(this._config)
+      await start(this._config)
       this._pairTimeout = setTimeout(() => {
         console.debug('no device, sending pair')
         send(new SendCarPlay('wifiPair'))

--- a/src/web/CarplayWeb.ts
+++ b/src/web/CarplayWeb.ts
@@ -88,14 +88,14 @@ export default class CarplayWeb {
 
   start = async (usbDevice: USBDevice) => {
     if (this._started) return
-    const { initialise, open, send } = this.dongleDriver
+    const { initialise, start, send } = this.dongleDriver
 
     console.debug('opening device')
     await usbDevice.open()
     await usbDevice.reset()
 
     await initialise(usbDevice)
-    await open(this._config)
+    await start(this._config)
     this._pairTimeout = setTimeout(() => {
       console.debug('no device, sending pair')
       send(new SendCarPlay('wifiPair'))

--- a/src/web/tsconfig.json
+++ b/src/web/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "target": "ES6",
-    "module": "ES2020",
+    "module": "ESNext",
     "moduleResolution": "NodeNext",
-    "lib": ["es2020", "DOM", "WebWorker"],
+    "lib": ["es2023", "DOM", "WebWorker"],
   },
-  "exclude": ["../node/*"]
+  "include": ["*"],
+  "exclude": []
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "src/web/*", "src/**/*.test.ts", "src/**/mocks"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,14 @@
 {
   "compilerOptions": {
     "outDir": "dist",
-    "target": "es2020",
-    "lib": ["es2020"],
-    "module": "commonjs",
+    "target": "es2022",
+    "lib": ["ES2023"],
+    "module": "node16",
+    "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "strict": true,
-    "declaration": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "node16",
     "sourceMap": true
   },
   "exclude": ["node_modules", "src/web/*"],


### PR DESCRIPTION
- Previous changes to open/init logic broke units tests - fixed.
- dist folder used to include test files - these are not needed in a distributed package - introduced a build tsconfig file that omits these.
- made sure to use up to date, supported module resolution and standards across tsconfigs.
- builds with a single command now, and has a watch mode where you can develop and it will keep re-building as files change