### PR TITLE
Handle already initialized dongle

### DIFF
--- a/src/node/CarplayNode.ts
+++ b/src/node/CarplayNode.ts
@@ -43,10 +43,6 @@ export default class CarplayNode {
     })
     driver.on('message', (message: Message) => {
       if (message instanceof Plugged) {
-        if (this._pairTimeout) {
-          clearTimeout(this._pairTimeout)
-          this._pairTimeout = null
-        }
         this.onmessage?.({ type: 'plugged' })
       } else if (message instanceof Unplugged) {
         this.onmessage?.({ type: 'unplugged' })
@@ -71,6 +67,18 @@ export default class CarplayNode {
           case AudioCommand.AudioPhonecallStop:
             mic.stop()
             break
+        }
+      }
+
+      if (
+        message instanceof Plugged ||
+        message instanceof AudioData ||
+        message instanceof VideoData ||
+        message instanceof MediaData
+      ) {
+        if (this._pairTimeout) {
+          clearTimeout(this._pairTimeout)
+          this._pairTimeout = null
         }
       }
     })
@@ -123,6 +131,8 @@ export default class CarplayNode {
       await initialise(device)
       await start(this._config)
       this._pairTimeout = setTimeout(() => {
+        this._pairTimeout = null
+
         console.debug('no device, sending pair')
         send(new SendCarPlay('wifiPair'))
       }, 15000)

--- a/src/node/CarplayNode.ts
+++ b/src/node/CarplayNode.ts
@@ -71,15 +71,14 @@ export default class CarplayNode {
       }
 
       if (
-        message instanceof Plugged ||
-        message instanceof AudioData ||
-        message instanceof VideoData ||
-        message instanceof MediaData
+        (message instanceof Plugged ||
+          message instanceof AudioData ||
+          message instanceof VideoData ||
+          message instanceof MediaData) &&
+        this._pairTimeout != null
       ) {
-        if (this._pairTimeout) {
-          clearTimeout(this._pairTimeout)
-          this._pairTimeout = null
-        }
+        clearTimeout(this._pairTimeout)
+        this._pairTimeout = null
       }
     })
     this.dongleDriver = driver

--- a/src/web/CarplayWeb.ts
+++ b/src/web/CarplayWeb.ts
@@ -79,15 +79,14 @@ export default class CarplayWeb {
 
       // Trigger internal event logic
       if (
-        message instanceof Plugged ||
-        message instanceof AudioData ||
-        message instanceof VideoData ||
-        message instanceof MediaData
+        (message instanceof Plugged ||
+          message instanceof AudioData ||
+          message instanceof VideoData ||
+          message instanceof MediaData) &&
+        this._pairTimeout != null
       ) {
-        if (this._pairTimeout) {
-          clearTimeout(this._pairTimeout)
-          this._pairTimeout = null
-        }
+        clearTimeout(this._pairTimeout)
+        this._pairTimeout = null
       }
     })
     this.dongleDriver = driver


### PR DESCRIPTION
This makes sure we do NOT send `wifiPair` when the dongle is already initialized and we're resuming a session

Fixes https://github.com/rhysmorgan134/node-CarPlay/issues/25

Ping @gozmanyoni for review 🙏 