### PR TITLE
Feature: clear wifiPair if already streaming + partial config

### DIFF
--- a/examples/carplay-web-app-direct/src/App.tsx
+++ b/examples/carplay-web-app-direct/src/App.tsx
@@ -11,16 +11,14 @@ import CarplayWeb, {
 import JMuxer from 'jmuxer'
 import useCarplayAudio from './useCarplayAudio'
 
-export const config: DongleConfig = {
-  dpi: 160,
-  nightMode: false,
-  hand: 0,
-  boxName: 'nodePlay',
-  width: window.innerWidth,
-  height: window.innerHeight,
+const width = window.innerWidth
+const height = window.innerHeight
+
+const config: Partial<DongleConfig> = {
+  width,
+  height,
   fps: 60,
   mediaDelay: 0,
-  audioTransferMode: false,
 }
 
 function App() {
@@ -139,7 +137,7 @@ function App() {
 
       const { offsetX: x, offsetY: y } = e.nativeEvent
       carplay.dongleDriver.send(
-        new SendTouch(x / config.width, y / config.height, action),
+        new SendTouch(x / width, y / height, action),
       )
     },
     [carplay, pointerdown],

--- a/examples/carplay-web-app-worker/src/App.tsx
+++ b/examples/carplay-web-app-worker/src/App.tsx
@@ -11,16 +11,14 @@ import JMuxer from 'jmuxer'
 import { CarPlayWorker } from './worker/types'
 import useCarplayAudio from './useCarplayAudio'
 
-export const config: DongleConfig = {
-  dpi: 160,
-  nightMode: false,
-  hand: 0,
-  boxName: 'nodePlay',
-  width: window.innerWidth,
-  height: window.innerHeight,
+const width = window.innerWidth
+const height = window.innerHeight
+
+const config: Partial<DongleConfig> = {
+  width,
+  height,
   fps: 60,
   mediaDelay: 0,
-  audioTransferMode: false,
 }
 
 function App() {
@@ -143,10 +141,10 @@ function App() {
         return
       }
 
-      const { offsetX, offsetY } = e.nativeEvent
+      const { offsetX: x, offsetY: y } = e.nativeEvent
       carplayWorker.postMessage({
         type: 'touch',
-        payload: { x: offsetX, y: offsetY, action },
+        payload: { x: x / width, y: y / height, action },
       })
     },
     [carplayWorker, pointerdown],

--- a/examples/carplay-web-app-worker/src/worker/carplay.ts
+++ b/examples/carplay-web-app-worker/src/worker/carplay.ts
@@ -10,7 +10,7 @@ import CarplayWeb, {
 import { Command } from './types'
 
 let carplayWeb: CarplayWeb | null = null
-let config: DongleConfig | null = null
+let config: Partial<DongleConfig> | null = null
 
 const handleMessage = (message: CarplayMessage) => {
   if (message instanceof VideoData) {
@@ -37,7 +37,7 @@ onmessage = async (event: MessageEvent<Command>) => {
     case 'touch':
       if (config && carplayWeb) {
         const { x, y, action } = event.data.payload
-        const data = new SendTouch(x / config.width, y / config.height, action)
+        const data = new SendTouch(x, y, action)
         carplayWeb.dongleDriver.send(data)
       }
       break

--- a/examples/carplay-web-app-worker/src/worker/types.ts
+++ b/examples/carplay-web-app-worker/src/worker/types.ts
@@ -8,7 +8,7 @@ export type CarplayWorkerMessage = { data: CarplayMessage }
 
 export type Command =
   | { type: 'stop' }
-  | { type: 'start'; payload: DongleConfig }
+  | { type: 'start'; payload: Partial<DongleConfig> }
   | { type: 'touch'; payload: { x: number; y: number; action: TouchAction } }
   | { type: 'microphoneInput'; payload: Buffer }
 

--- a/src/node/CarplayNode.ts
+++ b/src/node/CarplayNode.ts
@@ -34,8 +34,8 @@ export default class CarplayNode {
   private _config: DongleConfig
   public dongleDriver: DongleDriver
 
-  constructor(config: DongleConfig = DEFAULT_CONFIG) {
-    this._config = config
+  constructor(config: Partial<DongleConfig>) {
+    this._config = Object.assign({}, DEFAULT_CONFIG, config)
     const mic = new NodeMicrophone()
     const driver = new DongleDriver()
     mic.on('data', data => {
@@ -43,18 +43,18 @@ export default class CarplayNode {
     })
     driver.on('message', (message: Message) => {
       if (message instanceof Plugged) {
-        if (this._pairTimeout) {
-          clearTimeout(this._pairTimeout)
-          this._pairTimeout = null
-        }
+        this.clearPairTimeout()
         this.onmessage?.({ type: 'plugged' })
       } else if (message instanceof Unplugged) {
         this.onmessage?.({ type: 'unplugged' })
       } else if (message instanceof VideoData) {
+        this.clearPairTimeout()
         this.onmessage?.({ type: 'video', message })
       } else if (message instanceof AudioData) {
+        this.clearPairTimeout()
         this.onmessage?.({ type: 'audio', message })
       } else if (message instanceof MediaData) {
+        this.clearPairTimeout()
         this.onmessage?.({ type: 'media', message })
       } else if (message instanceof CarPlay) {
         this.onmessage?.({ type: 'carplay', message })
@@ -134,6 +134,13 @@ export default class CarplayNode {
     if (!initialised) {
       console.log('carplay not initialised, retrying in 2s')
       setTimeout(this.start, 2000)
+    }
+  }
+
+  private clearPairTimeout() {
+    if (this._pairTimeout) {
+      clearTimeout(this._pairTimeout)
+      this._pairTimeout = null
     }
   }
 

--- a/src/web/CarplayWeb.ts
+++ b/src/web/CarplayWeb.ts
@@ -8,7 +8,7 @@ import {
   SendCarPlay,
   CarPlay,
 } from '../modules/messages'
-import { DongleDriver, DongleConfig } from '../modules'
+import { DongleDriver, DongleConfig, DEFAULT_CONFIG } from '../modules'
 
 const { knownDevices } = DongleDriver
 
@@ -59,29 +59,36 @@ export default class CarplayWeb {
   private _config: DongleConfig
   public dongleDriver: DongleDriver
 
-  constructor(config: DongleConfig) {
-    this._config = config
+  constructor(config: Partial<DongleConfig>) {
+    this._config = Object.assign({}, DEFAULT_CONFIG, config)
     const driver = new DongleDriver()
     driver.on('message', (message: Message) => {
       if (message instanceof Plugged) {
-        if (this._pairTimeout) {
-          clearTimeout(this._pairTimeout)
-          this._pairTimeout = null
-        }
+        this.clearPairTimeout()
         this.onmessage?.({ type: 'plugged' })
       } else if (message instanceof Unplugged) {
         this.onmessage?.({ type: 'unplugged' })
       } else if (message instanceof VideoData) {
+        this.clearPairTimeout()
         this.onmessage?.({ type: 'video', message })
       } else if (message instanceof AudioData) {
+        this.clearPairTimeout()
         this.onmessage?.({ type: 'audio', message })
       } else if (message instanceof MediaData) {
+        this.clearPairTimeout()
         this.onmessage?.({ type: 'media', message })
       } else if (message instanceof CarPlay) {
         this.onmessage?.({ type: 'carplay', message })
       }
     })
     this.dongleDriver = driver
+  }
+
+  private clearPairTimeout() {
+    if (this._pairTimeout) {
+      clearTimeout(this._pairTimeout)
+      this._pairTimeout = null
+    }
   }
 
   public onmessage: ((ev: CarplayMessage) => void) | null = null


### PR DESCRIPTION
This fixes a small bug and adds a feature:

1. Bug - when a dongle is already streaming - clears the timeout to send a wifi pair command
2. Feature - CarplauNode and Web now receive Partial<DongleConfig> instead of the full object - allowing consumers to pass less props - for omitted props, default config will be used.