### PR TITLE
Fixes for Node.js side

### DIFF
--- a/examples/carplay-node-without-audio/package.json
+++ b/examples/carplay-node-without-audio/package.json
@@ -27,7 +27,7 @@
     "build": "npm run build:server && npm run build:client",
     "build:server": "esbuild server/index.ts --bundle --outfile=server/index.js --define:process.env.NODE_ENV=\\\"production\\\" --platform=node --external:usb --external:node-microphone --external:ws --external:express --external:cors --tree-shaking=true",
     "build:client": "esbuild client/index.tsx --bundle --outfile=public/bundle.js --define:process.env.NODE_ENV=\\\"production\\\" --alias:events=events --alias:stream=stream-browserify --alias:buffer=buffer --tree-shaking=true",
-    "watch:server": "npm run build:client -- --watch",
+    "watch:server": "npm run build:server -- --watch",
     "watch:client": "npm run build:client -- --watch",
     "start": "node server/index.js",
     "prepare": "npm run build"

--- a/src/node/CarplayNode.ts
+++ b/src/node/CarplayNode.ts
@@ -18,8 +18,7 @@ import {
   AudioCommand,
 } from '../modules/index.js'
 
-const USB_WAIT_PERIOD_MS = 500
-const USB_WAIT_RESTART_MS = 3000
+const USB_WAIT_PERIOD_MS = 3000
 
 export type CarplayMessage =
   | { type: 'plugged'; message?: undefined }
@@ -124,7 +123,7 @@ export default class CarplayNode {
     // or LIBUSB_TRANSFER_ERROR
 
     console.log('Reset device, finding again...')
-    await new Promise(resolve => setTimeout(resolve, USB_WAIT_RESTART_MS))
+    await new Promise(resolve => setTimeout(resolve, USB_WAIT_PERIOD_MS))
     // ^ Device disappears after reset for 1-3 seconds
 
     device = await this.findDevice()


### PR DESCRIPTION
- Fix for a typo in script in example
- Increased wait period during polls for usb dongle
  - This is important to make sure we don't hog the resources waiting for the dongle to appear. Since this is only applied when the dongle cannot be initially found, it shouldn't affect initial boot speed for most users.