### PR TITLE
Add package description for NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-carplay",
   "version": "4.0.0",
-  "description": "",
+  "description": "Carplay dongle driver for Node.js & Browser",
   "type": "module",
   "exports": {
     "./node": "./dist/node/index.js",


### PR DESCRIPTION
<img src="https://github.com/rhysmorgan134/node-CarPlay/assets/4278113/f55da3ca-d24c-4acd-a197-60574c003cf5">

This is what npm infers the description of the package to be, since one is not specified. This PR aims to fix that