### PR TITLE
Offload all dongle data procesing from the main thread

### DIFF
--- a/examples/carplay-web-app/package-lock.json
+++ b/examples/carplay-web-app/package-lock.json
@@ -19,7 +19,7 @@
         "buffer": "^6.0.3",
         "http-proxy-middleware": "^2.0.6",
         "node-carplay": "file:../../",
-        "pcm-ringbuf-player": "^0.0.5",
+        "pcm-ringbuf-player": "git@github.com:gozmanyoni/pcm-ringbuf-player.git#public-rb",
         "process": "^0.11.10",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -11341,8 +11341,8 @@
     },
     "node_modules/pcm-ringbuf-player": {
       "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/pcm-ringbuf-player/-/pcm-ringbuf-player-0.0.5.tgz",
-      "integrity": "sha512-mVVSGor+g2Z8a5OEDOJdQPxwhshmTQG/kN2jURgEpuf2zHO+2L4tYXRMm1MdUi9hFO3Tj/KKoebvRvtHhb3YmA==",
+      "resolved": "git+ssh://git@github.com/gozmanyoni/pcm-ringbuf-player.git#82f70b7b46363fcc6a050b010c770a2d314c3dd1",
+      "license": "MIT",
       "dependencies": {
         "ringbuf.js": "^0.3.6"
       }

--- a/examples/carplay-web-app/package-lock.json
+++ b/examples/carplay-web-app/package-lock.json
@@ -19,7 +19,7 @@
         "buffer": "^6.0.3",
         "http-proxy-middleware": "^2.0.6",
         "node-carplay": "file:../../",
-        "pcm-ringbuf-player": "git@github.com:gozmanyoni/pcm-ringbuf-player.git#public-rb",
+        "pcm-ringbuf-player": "0.0.6",
         "process": "^0.11.10",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -11340,9 +11340,9 @@
       }
     },
     "node_modules/pcm-ringbuf-player": {
-      "version": "0.0.5",
-      "resolved": "git+ssh://git@github.com/gozmanyoni/pcm-ringbuf-player.git#82f70b7b46363fcc6a050b010c770a2d314c3dd1",
-      "license": "MIT",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/pcm-ringbuf-player/-/pcm-ringbuf-player-0.0.6.tgz",
+      "integrity": "sha512-FbfkvbjxiI41dWnUaQKi8exSG7jCjqYKsilpVak11ZEeqlRdLlELXSA43Bg2IRnFflX1eyEObqvMzSBh4ybcYQ==",
       "dependencies": {
         "ringbuf.js": "^0.3.6"
       }

--- a/examples/carplay-web-app/package.json
+++ b/examples/carplay-web-app/package.json
@@ -14,7 +14,7 @@
     "buffer": "^6.0.3",
     "http-proxy-middleware": "^2.0.6",
     "node-carplay": "file:../../",
-    "pcm-ringbuf-player": "^0.0.5",
+    "pcm-ringbuf-player": "git@github.com:gozmanyoni/pcm-ringbuf-player.git#public-rb",
     "process": "^0.11.10",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/examples/carplay-web-app/package.json
+++ b/examples/carplay-web-app/package.json
@@ -14,7 +14,7 @@
     "buffer": "^6.0.3",
     "http-proxy-middleware": "^2.0.6",
     "node-carplay": "file:../../",
-    "pcm-ringbuf-player": "git@github.com:gozmanyoni/pcm-ringbuf-player.git#public-rb",
+    "pcm-ringbuf-player": "0.0.6",
     "process": "^0.11.10",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/examples/carplay-web-app/src/App.tsx
+++ b/examples/carplay-web-app/src/App.tsx
@@ -79,7 +79,7 @@ function App() {
     return worker
   }, [])
 
-  const { processAudio, startRecording, stopRecording } = useCarplayAudio(
+  const { processAudio, getAudioPlayer, startRecording, stopRecording } = useCarplayAudio(
     carplayWorker,
     micChannel.port2,
   )
@@ -102,11 +102,13 @@ function App() {
         case 'unplugged':
           setPlugged(false)
           break
+        case 'getAudioPlayer':
+          clearRetryTimeout()
+          getAudioPlayer(ev.data.message)
+          break
         case 'audio':
           clearRetryTimeout()
-
-          const { message: audio } = ev.data
-          processAudio(audio)
+          processAudio(ev.data.message)
           break
         case 'media':
           //TODO: implement

--- a/examples/carplay-web-app/src/App.tsx
+++ b/examples/carplay-web-app/src/App.tsx
@@ -100,7 +100,7 @@ function App() {
         case 'unplugged':
           setPlugged(false)
           break
-        case 'getAudioPlayer':
+        case 'requestBuffer':
           clearRetryTimeout()
           getAudioPlayer(ev.data.message)
           break

--- a/examples/carplay-web-app/src/App.tsx
+++ b/examples/carplay-web-app/src/App.tsx
@@ -79,10 +79,8 @@ function App() {
     return worker
   }, [])
 
-  const { processAudio, getAudioPlayer, startRecording, stopRecording } = useCarplayAudio(
-    carplayWorker,
-    micChannel.port2,
-  )
+  const { processAudio, getAudioPlayer, startRecording, stopRecording } =
+    useCarplayAudio(carplayWorker, micChannel.port2)
 
   const clearRetryTimeout = useCallback(() => {
     if (retryTimeoutRef.current) {
@@ -141,6 +139,7 @@ function App() {
   }, [
     carplayWorker,
     clearRetryTimeout,
+    getAudioPlayer,
     processAudio,
     renderWorker,
     startRecording,

--- a/examples/carplay-web-app/src/App.tsx
+++ b/examples/carplay-web-app/src/App.tsx
@@ -23,6 +23,7 @@ const width = window.innerWidth
 const height = window.innerHeight
 
 const videoChannel = new MessageChannel()
+const micChannel = new MessageChannel()
 
 const config: Partial<DongleConfig> = {
   width,
@@ -69,13 +70,19 @@ function App() {
     ) as CarPlayWorker
     const payload = {
       videoPort: videoChannel.port1,
+      microphonePort: micChannel.port1,
     }
-    worker.postMessage({ type: 'initialise', payload }, [videoChannel.port1])
+    worker.postMessage({ type: 'initialise', payload }, [
+      videoChannel.port1,
+      micChannel.port1,
+    ])
     return worker
   }, [])
 
-  const { processAudio, startRecording, stopRecording } =
-    useCarplayAudio(carplayWorker)
+  const { processAudio, startRecording, stopRecording } = useCarplayAudio(
+    carplayWorker,
+    micChannel.port2,
+  )
 
   const clearRetryTimeout = useCallback(() => {
     if (retryTimeoutRef.current) {

--- a/examples/carplay-web-app/src/useCarplayAudio.ts
+++ b/examples/carplay-web-app/src/useCarplayAudio.ts
@@ -31,18 +31,22 @@ const useCarplayAudio = (
       audioPlayers.set(audioKey, player)
       player.volume(defaultAudioVolume)
       player.start()
+      worker.postMessage({
+        type: 'audioPlayer',
+        payload: {
+          sab: player.rb.buf,
+          format,
+          audioType,
+        },
+      })
       return player
     },
-    [audioPlayers],
+    [audioPlayers, worker],
   )
 
   const processAudio = useCallback(
     (audio: AudioData) => {
-      if (audio.data) {
-        const { data } = audio
-        const player = getAudioPlayer(audio)
-        player.feed(data)
-      } else if (audio.volumeDuration) {
+      if (audio.volumeDuration) {
         const { volume, volumeDuration } = audio
         const player = getAudioPlayer(audio)
         player.volume(volume, volumeDuration)
@@ -92,7 +96,7 @@ const useCarplayAudio = (
     mic?.stop()
   }, [mic])
 
-  return { processAudio, startRecording, stopRecording }
+  return { processAudio, getAudioPlayer, startRecording, stopRecording }
 }
 
 export default useCarplayAudio

--- a/examples/carplay-web-app/src/useCarplayAudio.ts
+++ b/examples/carplay-web-app/src/useCarplayAudio.ts
@@ -35,7 +35,7 @@ const useCarplayAudio = (
       worker.postMessage({
         type: 'audioBuffer',
         payload: {
-          sab: player.rb.buf,
+          sab: player.getRawBuffer(),
           decodeType,
           audioType,
         },

--- a/examples/carplay-web-app/src/worker/CarPlay.worker.ts
+++ b/examples/carplay-web-app/src/worker/CarPlay.worker.ts
@@ -60,7 +60,7 @@ onmessage = async (event: MessageEvent<Command>) => {
         }
       }
       break
-    case 'audioPlayer':
+    case 'audioBuffer':
       const { sab, decodeType, audioType } = event.data.payload
       const audioKey = createAudioPlayerKey(decodeType, audioType)
       audioBuffers[audioKey] = new RingBuffer(sab, Int16Array)

--- a/examples/carplay-web-app/src/worker/CarPlay.worker.ts
+++ b/examples/carplay-web-app/src/worker/CarPlay.worker.ts
@@ -26,10 +26,13 @@ const handleMessage = (message: CarplayMessage) => {
 
 onmessage = async (event: MessageEvent<Command>) => {
   switch (event.data.type) {
+    case 'initialise':
+      if (carplayWeb) return
+      videoPort = event.data.payload.videoPort
+      break
     case 'start':
       if (carplayWeb) return
       config = event.data.payload.config
-      videoPort = event.data.payload.videoPort
       const device = await findDevice()
       if (device) {
         carplayWeb = new CarplayWeb(config)

--- a/examples/carplay-web-app/src/worker/render/Render.worker.ts
+++ b/examples/carplay-web-app/src/worker/render/Render.worker.ts
@@ -19,6 +19,7 @@ export class RenderWorker {
   constructor(private host: HostType) {}
 
   private renderer: FrameRenderer | null = null
+  private videoPort: MessagePort | null = null
   private pendingFrame: VideoFrame | null = null
   private startTime: number | null = null
   private frameCount = 0
@@ -78,6 +79,10 @@ export class RenderWorker {
         this.renderer = new WebGPURenderer(event.canvas)
         break
     }
+    this.videoPort = event.videoPort
+    this.videoPort.onmessage = ev => {
+      this.onFrame(ev.data as RenderEvent)
+    }
 
     if (event.reportFps) {
       setInterval(() => {
@@ -119,8 +124,6 @@ const worker = new RenderWorker(self)
 scope.addEventListener('message', (event: MessageEvent<WorkerEvent>) => {
   if (event.data.type === 'init') {
     worker.init(event.data as InitEvent)
-  } else if (event.data.type === 'frame') {
-    worker.onFrame(event.data as RenderEvent)
   }
 })
 

--- a/examples/carplay-web-app/src/worker/render/RenderEvents.ts
+++ b/examples/carplay-web-app/src/worker/render/RenderEvents.ts
@@ -17,6 +17,7 @@ export class InitEvent implements WorkerEvent {
 
   constructor(
     public canvas: OffscreenCanvas,
+    public videoPort: MessagePort,
     public renderer: Renderer = 'webgl',
     public reportFps: boolean = false,
   ) {}

--- a/examples/carplay-web-app/src/worker/types.ts
+++ b/examples/carplay-web-app/src/worker/types.ts
@@ -4,6 +4,7 @@ export type CarplayWorkerMessage = { data: CarplayMessage }
 
 export type InitialisePayload = {
   videoPort: MessagePort
+  microphonePort: MessagePort
 }
 
 export type StartPayload = {

--- a/examples/carplay-web-app/src/worker/types.ts
+++ b/examples/carplay-web-app/src/worker/types.ts
@@ -2,14 +2,18 @@ import { DongleConfig, TouchAction, CarplayMessage } from 'node-carplay/web'
 
 export type CarplayWorkerMessage = { data: CarplayMessage }
 
+export type InitialisePayload = {
+  videoPort: MessagePort
+}
+
 export type StartPayload = {
   config: Partial<DongleConfig>
-  videoPort: MessagePort
 }
 
 export type Command =
   | { type: 'frame' }
   | { type: 'stop' }
+  | { type: 'initialise'; payload: InitialisePayload }
   | { type: 'start'; payload: StartPayload }
   | { type: 'touch'; payload: { x: number; y: number; action: TouchAction } }
   | { type: 'microphoneInput'; payload: Int16Array }

--- a/examples/carplay-web-app/src/worker/types.ts
+++ b/examples/carplay-web-app/src/worker/types.ts
@@ -1,10 +1,24 @@
-import { DongleConfig, TouchAction, CarplayMessage } from 'node-carplay/web'
+import {
+  DongleConfig,
+  TouchAction,
+  CarplayMessage,
+  AudioFormat,
+  AudioData,
+} from 'node-carplay/web'
 
-export type CarplayWorkerMessage = { data: CarplayMessage }
+export type CarplayWorkerMessage =
+  | { data: CarplayMessage }
+  | { data: { type: 'getAudioPlayer'; message: AudioData } }
 
 export type InitialisePayload = {
   videoPort: MessagePort
   microphonePort: MessagePort
+}
+
+export type AudioPlayerPayload = {
+  sab: SharedArrayBuffer
+  format: AudioFormat
+  audioType: number
 }
 
 export type StartPayload = {
@@ -15,9 +29,9 @@ export type Command =
   | { type: 'frame' }
   | { type: 'stop' }
   | { type: 'initialise'; payload: InitialisePayload }
+  | { type: 'audioPlayer'; payload: AudioPlayerPayload }
   | { type: 'start'; payload: StartPayload }
   | { type: 'touch'; payload: { x: number; y: number; action: TouchAction } }
-  | { type: 'microphoneInput'; payload: Int16Array }
 
 export interface CarPlayWorker
   extends Omit<Worker, 'postMessage' | 'onmessage'> {

--- a/examples/carplay-web-app/src/worker/types.ts
+++ b/examples/carplay-web-app/src/worker/types.ts
@@ -2,13 +2,14 @@ import {
   DongleConfig,
   TouchAction,
   CarplayMessage,
-  AudioFormat,
   AudioData,
 } from 'node-carplay/web'
 
+export type AudioPlayerKey = string & { __brand: 'AudioPlayerKey' }
+
 export type CarplayWorkerMessage =
   | { data: CarplayMessage }
-  | { data: { type: 'getAudioPlayer'; message: AudioData } }
+  | { data: { type: 'requestBuffer'; message: AudioData } }
 
 export type InitialisePayload = {
   videoPort: MessagePort
@@ -17,7 +18,7 @@ export type InitialisePayload = {
 
 export type AudioPlayerPayload = {
   sab: SharedArrayBuffer
-  format: AudioFormat
+  decodeType: number
   audioType: number
 }
 
@@ -29,7 +30,7 @@ export type Command =
   | { type: 'frame' }
   | { type: 'stop' }
   | { type: 'initialise'; payload: InitialisePayload }
-  | { type: 'audioPlayer'; payload: AudioPlayerPayload }
+  | { type: 'audioBuffer'; payload: AudioPlayerPayload }
   | { type: 'start'; payload: StartPayload }
   | { type: 'touch'; payload: { x: number; y: number; action: TouchAction } }
 

--- a/examples/carplay-web-app/src/worker/types.ts
+++ b/examples/carplay-web-app/src/worker/types.ts
@@ -2,10 +2,15 @@ import { DongleConfig, TouchAction, CarplayMessage } from 'node-carplay/web'
 
 export type CarplayWorkerMessage = { data: CarplayMessage }
 
+export type StartPayload = {
+  config: Partial<DongleConfig>
+  videoPort: MessagePort
+}
+
 export type Command =
   | { type: 'frame' }
   | { type: 'stop' }
-  | { type: 'start'; payload: Partial<DongleConfig> }
+  | { type: 'start'; payload: StartPayload }
   | { type: 'touch'; payload: { x: number; y: number; action: TouchAction } }
   | { type: 'microphoneInput'; payload: Int16Array }
 

--- a/examples/carplay-web-app/src/worker/utils.ts
+++ b/examples/carplay-web-app/src/worker/utils.ts
@@ -1,0 +1,8 @@
+import { decodeTypeMap } from 'node-carplay/web'
+import { AudioPlayerKey } from './types'
+
+export const createAudioPlayerKey = (decodeType: number, audioType: number) => {
+  const format = decodeTypeMap[decodeType]
+  const audioKey = [format.frequency, format.channel, audioType].join('_')
+  return audioKey as AudioPlayerKey
+}

--- a/examples/carplay-web-app/tsconfig.json
+++ b/examples/carplay-web-app/tsconfig.json
@@ -16,7 +16,7 @@
     "noEmit": true,
     "jsx": "react-jsx",
     "types": ["@webgpu/types"],
-    "typeRoots": ["types", "node_modules/@types"],
+    "typeRoots": ["types", "node_modules/@types"]
   },
   "include": ["src", "types"]
 }

--- a/examples/carplay-web-app/tsconfig.json
+++ b/examples/carplay-web-app/tsconfig.json
@@ -15,7 +15,8 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "types": ["@webgpu/types"]
+    "types": ["@webgpu/types"],
+    "typeRoots": ["types", "node_modules/@types"],
   },
-  "include": ["src"]
+  "include": ["src", "types"]
 }

--- a/examples/carplay-web-app/types/ringbuf.js/index.d.ts
+++ b/examples/carplay-web-app/types/ringbuf.js/index.d.ts
@@ -1,0 +1,30 @@
+type TypedArray =
+  | Int8Array
+  | Uint8Array
+  | Uint8ClampedArray
+  | Int16Array
+  | Uint16Array
+  | Int32Array
+  | Uint32Array
+  | Float32Array
+  | Float64Array
+
+type TypedArrayConstructor<T> = {
+  new (): T
+  new (size: number): T
+  new (buffer: ArrayBuffer, byteOffset?: number, length?: number): T
+  BYTES_PER_ELEMENT: number
+}
+
+declare module 'ringbuf.js' {
+  export class RingBuffer<T extends TypedArray> {
+    constructor(sab: SharedArrayBuffer, type: TypedArrayConstructor<T>)
+    buf: SharedArrayBuffer
+    push(elements: T, length?: number, offset = 0): number
+    pop(elements: TypedArray, length: number, offset = 0): number
+    empty(): boolean
+    full(): boolean
+    capacity(): number
+    availableRead(): number
+  }
+}

--- a/src/web/WebMicrophone.ts
+++ b/src/web/WebMicrophone.ts
@@ -7,7 +7,7 @@ export default class WebMicrophone extends EventEmitter {
   private inputStream: MediaStreamAudioSourceNode
   private recorder: AudioWorkletNode | null = null
 
-  constructor(mediaStream: MediaStream) {
+  constructor(mediaStream: MediaStream, messagePort: MessagePort) {
     super()
     const audioContext = new AudioContext({ sampleRate: this.sampleRate })
     this.inputStream = audioContext.createMediaStreamSource(mediaStream)
@@ -16,13 +16,8 @@ export default class WebMicrophone extends EventEmitter {
       .addModule(new URL('./recorder.worklet.js', import.meta.url))
       .then(() => {
         this.recorder = new AudioWorkletNode(audioContext, 'recorder.worklet')
-        this.recorder.port.onmessage = this.handleData
+        this.recorder.port.postMessage(messagePort, [messagePort])
       })
-  }
-
-  private handleData = async (e: { data: Int16Array }) => {
-    if (!this.active) return
-    this.emit('data', e.data)
   }
 
   async start() {

--- a/src/web/recorder.worklet.ts
+++ b/src/web/recorder.worklet.ts
@@ -2,10 +2,14 @@ class RecorderProcessor extends AudioWorkletProcessor {
   bufferSize = 2048
   _bytesWritten = 0
   _buffer = new Float32Array(this.bufferSize)
+  _outPort: MessagePort | undefined
 
   constructor() {
     super()
     this.initBuffer()
+    this.port.onmessage = ev => {
+      this._outPort = ev.data
+    }
   }
 
   private floatTo16BitPCM(input: Float32Array) {
@@ -62,7 +66,9 @@ class RecorderProcessor extends AudioWorkletProcessor {
         ? this._buffer.slice(0, this._bytesWritten)
         : this._buffer,
     )
-    this.port.postMessage(data, [data.buffer])
+    if (this._outPort) {
+      this._outPort.postMessage(data, [data.buffer])
+    }
     this.initBuffer()
   }
 }


### PR DESCRIPTION
To partially address https://github.com/rhysmorgan134/node-CarPlay/issues/37#issuecomment-1802456537 and come up with a pattern to do this I tackled offloading the video frames off the main thread using a MessageChannel.

What we have remaining is audio:

1. Playing audio which should probably done by sending the SharedArrayBuffer over to the carplay worker (together with the audio type), and write to it there instead of on the main thread - we will need to do this for every player created, so the carplay worked needs to be extended with new message types - one to request a player and one to receive and set one. the player has to be created on the main thread as you cannot initialize an audio context in web workers.
2. Mic input - can probably use a MessageChannel as well and skip the main thread completely.
