### PR TITLE
Fix startnode.ts filename case, complete the default startup parameters and fix type error

### DIFF
--- a/scripts/startNode.ts
+++ b/scripts/startNode.ts
@@ -1,4 +1,5 @@
 import { DongleConfig } from '../src/modules/DongleDriver.js'
+import { PhoneType } from '../src/modules/index.js'
 import CarplayNode from '../src/node/CarplayNode.js'
 const config: DongleConfig = {
   dpi: 160,
@@ -10,6 +11,20 @@ const config: DongleConfig = {
   fps: 20,
   mediaDelay: 300,
   audioTransferMode: false,
+  format: 5,
+  iBoxVersion: 2,
+  packetMax: 49152,
+  phoneWorkMode: 2,
+  wifiType: '5ghz',
+  micType: 'os',
+  phoneConfig: {
+    [PhoneType.CarPlay]: {
+      frameInterval: 5000,
+    },
+    [PhoneType.AndroidAuto]: {
+      frameInterval: null,
+    },
+  },
 }
 
 const carplay = new CarplayNode(config)

--- a/src/node/CarplayNode.ts
+++ b/src/node/CarplayNode.ts
@@ -46,7 +46,7 @@ export default class CarplayNode {
       if (message instanceof Plugged) {
         this.clearPairTimeout()
         this.clearFrameInterval()
-        const phoneTypeConfg = this._config.phoneConfig[message.phoneType]
+        const phoneTypeConfg = this._config.phoneConfig?.[message.phoneType]
         if (phoneTypeConfg?.frameInterval) {
           this._frameInterval = setInterval(
             () => {


### PR DESCRIPTION
When I try to run it, I get these errors.
The `startnode.ts` filename is inconsistent with the `pacakge.json` `start:node`. 
The default start config parameters are missing some values.

By the way, It works fine with node v16.x. When I use a version >= node v18:
```
npm run start:node
# error
TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts"
```